### PR TITLE
Update interface.c to avoid error messages

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -576,7 +576,11 @@ void interpreter_chat_mode (char *line) {
     do_mark_read (chat_mode_id);
     return;
   }
-  do_send_message (chat_mode_id, line, strlen (line));
+  int t;
+  char *s = next_token (&t);
+  if (s) {
+    do_send_message (chat_mode_id, line, strlen (line));
+  }
 }
 
 void interpreter (char *line UU) {


### PR DESCRIPTION
When hitting enter (without writing anything) in an chat prompt always appears an error message telling you that the message is empty.
Checking the content of the line can avoid this.
I don't know is this behaviour is wrong or right.
So please forgive me if it doesn’t make sense.
