### PR TITLE
catch NULL input in interpreter_chat_mode

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -560,7 +560,8 @@ void work_modifier (const char *s, int l) {
 
 
 void interpreter_chat_mode (char *line) {
-  if (!strncmp (line, "/exit", 5) || !strncmp (line, "/quit", 5)) {
+  if (line == NULL || /* EOF received */
+          !strncmp (line, "/exit", 5) || !strncmp (line, "/quit", 5)) {
     in_chat_mode = 0;
     update_prompt ();
     return;


### PR DESCRIPTION
This is a very minimal fix that resolves #89

There is no line break, so you get an additional prompt on the current line if you terminate the chat with ctrl+d. Someone who knows the code base a bit better could probably put a newline in the correct place :)
