### PR TITLE
ignore build-files in .gitignore so git is clean after building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.h
 config.log
 config.status
 .idea/
+nbproject/


### PR DESCRIPTION
after compiling the git tree isn't "clean" anymore
