### PR TITLE
Remove biased shell signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Documentation for MTproto protocol is available here: http://core.telegram.org/m
 
 Clone GitHub Repository
 
-    $ git clone https://github.com/vysheng/tg.git && cd tg
+     git clone https://github.com/vysheng/tg.git && cd tg
 
 or download and extract zip
 
-    $ wget https://github.com/vysheng/tg/archive/master.zip -O tg-master.zip
-    $ unzip tg-master.zip && cd tg-master
+     wget https://github.com/vysheng/tg/archive/master.zip -O tg-master.zip
+     unzip tg-master.zip && cd tg-master
 
 #### Linux and BSDs
 
@@ -26,39 +26,39 @@ If you do not want to use them pass options --disable-libconfig and --disable-li
 
 On ubuntu use: 
 
-    $ sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev
+     sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev
 
 On gentoo:
 
-    $ sudo emerge -av sys-libs/readline dev-libs/libconfig dev-libs/openssl dev-lang/lua
+     sudo emerge -av sys-libs/readline dev-libs/libconfig dev-libs/openssl dev-lang/lua
 
 On Fedora:
 
-    $ sudo yum install lua-devel openssl-devel libconfig-devel readline-devel
+     sudo yum install lua-devel openssl-devel libconfig-devel readline-devel
 
 On FreeBSD:
 
-    $ pkg install libconfig libexecinfo lua52
+     pkg install libconfig libexecinfo lua52
 
 On OpenBSD:
 
-    $ pkg_add libconfig libexecinfo lua
+     pkg_add libconfig libexecinfo lua
 
 Then,
 
-    $ ./configure
-    $ make
+     ./configure
+     make
 
 #### Mac OS X
 
 The client depends on [readline library](http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html) and [libconfig](http://www.hyperrealm.com/libconfig/), which are not included in OS X by default. You have to install these libraries manually, e.g. using [Homebrew](http://brew.sh/).
 
-    $ brew install libconfig
-    $ brew install readline
-    $ brew install lua
-    $ export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.2.4/include"
-    $ export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.2.4/lib"
-    $ ./configure && make
+     brew install libconfig
+     brew install readline
+     brew install lua
+     export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.2.4/include"
+     export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.2.4/lib"
+     ./configure && make
 
 Thanks to [@jfontan](https://github.com/vysheng/tg/issues/3#issuecomment-28293731) for this solution.
 
@@ -71,8 +71,8 @@ Install these ports:
 
 Then build:
 
-    $ env CC=clang CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib LUA=/usr/local/bin/lua52 LUA_INCLUDE=-I/usr/local/include/lua52 LUA_LIB=-llua-5.2 ./configure
-    $ make
+     env CC=clang CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib LUA=/usr/local/bin/lua52 LUA_INCLUDE=-I/usr/local/include/lua52 LUA_LIB=-llua-5.2 ./configure
+     make
 
 #### Other UNIX
 


### PR DESCRIPTION
Not everybody uses bash, you know. Especially the people on *BSD, which you still listed as '$'
