### PR TITLE
telegram-cli gentoo ebuild pubkey fix

### DIFF
--- a/gentoo/telegram-cli/telegram-cli-9999.ebuild
+++ b/gentoo/telegram-cli/telegram-cli-9999.ebuild
@@ -27,5 +27,5 @@ src_install() {
 	newbin telegram telegram-cli
 
 	insinto /etc/telegram-cli/
-	newins tg.pub server.pub
+	newins tg-server.pub server.pub
 }


### PR DESCRIPTION
The server's pubkey filename changed in the source tree, so ebuild has to be adapted.
