### PR TITLE
Add default server.pub to /etc/telegram

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,2 @@
 telegram        usr/bin
+server.pub      etc/telegram

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,9 @@ VERSION=$(shell dpkg-parsechangelog | sed -n 's/^Version: //p' | cut -f1 -d'-')
 PACKAGE_NAME=$(shell dpkg-parsechangelog | sed -n 's/^Source: //p')
 
 %:
+	cp tg-server.pub server.pub
 	dh $@  --with autotools-dev
+	rm server.pub
 
 build-orig:
 	mkdir -p $(PACKAGE_NAME)-$(VERSION)


### PR DESCRIPTION
server.pub is missing in the default Debian package.
