### PR TITLE
Remove unneeded Mac OS X instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,6 @@ The client depends on [readline library](http://cnswww.cns.cwru.edu/php/chet/rea
 
 Thanks to [@jfontan](https://github.com/vysheng/tg/issues/3#issuecomment-28293731) for this solution.
 
-
-Install these ports:
-
-* devel/libconfig
-* devel/libexecinfo
-* lang/lua52
-
-Then build:
-
-     env CC=clang CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib LUA=/usr/local/bin/lua52 LUA_INCLUDE=-I/usr/local/include/lua52 LUA_LIB=-llua-5.2 ./configure
-     make
-
 #### Other UNIX
 
 If you manage to launch it on other UNIX, please let me know.


### PR DESCRIPTION
Remove stray FreeBSD instructions left in Mac OS X section due to partial revert of c373008, see comments of 1cc2ffe and 1f505031.
