### PR TITLE
Added Debian to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or download and extract zip
 Install libs: readline or libedit, openssl and (if you want to use config) libconfig and liblua.
 If you do not want to use them pass options --disable-libconfig and --disable-liblua respectively.
 
-On ubuntu use: 
+On Ubuntu/Debian use: 
 
      sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev
 


### PR DESCRIPTION
The Ubuntu instructions work for Debian. See https://github.com/vysheng/tg/issues/128
