### PR TITLE
fixed RAND_bytes return code checking

### DIFF
--- a/tools.c
+++ b/tools.c
@@ -269,7 +269,7 @@ double tglt_get_double_time (void) {
 }
 
 void tglt_secure_random (void *s, int l) {
-  if (RAND_bytes (s, l) < 0) {
+  if (RAND_bytes (s, l) <= 0) {
     /*if (allow_weak_random) {
       RAND_pseudo_bytes (s, l);
     } else {*/


### PR DESCRIPTION
https://www.openssl.org/docs/crypto/RAND_bytes.html#RETURN_VALUES

"RAND_bytes() returns 1 on success, 0 otherwise. ... return -1 if they are not supported by the current RAND method"
