### PR TITLE
netinet/in.h is required for struct sockaddr_in

### DIFF
--- a/main.c
+++ b/main.c
@@ -59,6 +59,7 @@
 
 #include <grp.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
 #include "telegram.h"
 #include "loop.h"


### PR DESCRIPTION
main.c:739:24: error: variable has incomplete type 'struct sockaddr_in'
    struct sockaddr_in serv_addr;
