### PR TITLE
FreeBSD-specific fixes

### DIFF
--- a/mtproto-client.c
+++ b/mtproto-client.c
@@ -80,7 +80,7 @@
 #define MAX_NET_RES        (1L << 16)
 //extern int log_level;
 
-#ifndef HAVE___BUILTIN_BSWAP32
+#if !defined(HAVE___BUILTIN_BSWAP32) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
 static inline unsigned __builtin_bswap32(unsigned x) {
   return ((x << 24) & 0xff000000 ) |
   ((x << 8) & 0x00ff0000 ) |

--- a/net.c
+++ b/net.c
@@ -26,11 +26,11 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <sys/types.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/fcntl.h>
-#include <sys/types.h>
 #include <sys/socket.h>
 #include <errno.h>
 #include <stdio.h>


### PR DESCRIPTION
- do not define bswap32 on FreebSD (and OpenBSD I guess)
- netinet/tcp.h requires sys/types.h
