### PR TITLE
pick home and config path from environment if set.

### DIFF
--- a/main.c
+++ b/main.c
@@ -247,11 +247,13 @@ void running_for_first_time (void) {
   }
   tasprintf (&config_filename, "%s/%s", config_directory, CONFIG_FILE);
   config_filename = make_full_path (config_filename);
+  if (!disable_output) {
+    printf ("I: config dir=[%s]\n", config_directory);
+  }
   // printf ("I: config file=[%s]\n", config_filename);
 
   int config_file_fd;
   char *config_directory = get_config_directory ();
-  printf ("I: config dir=[%s]\n", config_directory);
   //char *downloads_directory = get_downloads_directory ();
 
   if (!mkdir (config_directory, CONFIG_DIRECTORY_MODE)) {


### PR DESCRIPTION
@ char *get_config_directory (void)

``` c++
 tasprintf (&config_directory, "%s/" PROG_NAME, config_directory);
 // :TODO: someone check whether it could be required to pass tasprintf
 // a tstrdup()ed config_directory instead; works for me without.
 // should work b/c this scope's lifespan encompasses tasprintf()
```

Also the [XDG basedir spec](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) requirement to use `~/.config/$APPNAME` as the fallback default is ignored in order to preserve compatibility.
