### PR TITLE
Add an option to use IDs instead of names

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -103,6 +103,7 @@ struct in_ev *notify_ev;
 
 extern int usfd;
 extern int sfd;
+extern int use_ids;
 
 int is_same_word (const char *s, size_t l, const char *word) {
   return s && word && strlen (word) == l && !memcmp (s, word, l);
@@ -2335,7 +2336,7 @@ int unknown_user_list[1000];
 void print_user_name (struct in_ev *ev, tgl_peer_id_t id, tgl_peer_t *U) {
   assert (tgl_get_peer_type (id) == TGL_PEER_USER);
   mpush_color (ev, COLOR_RED);
-  if (!U) {
+  if (!U || use_ids) {
     mprintf (ev, "user#%d", tgl_get_peer_id (id));
     int i;
     int ok = 1;
@@ -2374,7 +2375,7 @@ void print_user_name (struct in_ev *ev, tgl_peer_id_t id, tgl_peer_t *U) {
 void print_chat_name (struct in_ev *ev, tgl_peer_id_t id, tgl_peer_t *C) {
   assert (tgl_get_peer_type (id) == TGL_PEER_CHAT);
   mpush_color (ev, COLOR_MAGENTA);
-  if (!C) {
+  if (!C || use_ids) {
     mprintf (ev, "chat#%d", tgl_get_peer_id (id));
   } else {
     mprintf (ev, "%s", C->chat.title);
@@ -2385,7 +2386,7 @@ void print_chat_name (struct in_ev *ev, tgl_peer_id_t id, tgl_peer_t *C) {
 void print_encr_chat_name (struct in_ev *ev, tgl_peer_id_t id, tgl_peer_t *C) {
   assert (tgl_get_peer_type (id) == TGL_PEER_ENCR_CHAT);
   mpush_color (ev, COLOR_MAGENTA);
-  if (!C) {
+  if (!C || use_ids) {
     mprintf (ev, "encr_chat#%d", tgl_get_peer_id (id));
   } else {
     mprintf (ev, "%s", C->print_name);
@@ -2396,7 +2397,7 @@ void print_encr_chat_name (struct in_ev *ev, tgl_peer_id_t id, tgl_peer_t *C) {
 void print_encr_chat_name_full (struct in_ev *ev, tgl_peer_id_t id, tgl_peer_t *C) {
   assert (tgl_get_peer_type (id) == TGL_PEER_ENCR_CHAT);
   mpush_color (ev, COLOR_MAGENTA);
-  if (!C) {
+  if (!C || use_ids) {
     mprintf (ev, "encr_chat#%d", tgl_get_peer_id (id));
   } else {
     mprintf (ev, "%s", C->print_name);

--- a/main.c
+++ b/main.c
@@ -111,6 +111,7 @@ int readline_disabled;
 int disable_output;
 int reset_authorization;
 int port;
+int use_ids;
 char *start_command;
 
 void set_default_username (const char *s) {
@@ -465,6 +466,7 @@ void usage (void) {
   printf ("  -P <port>           port to listen for input commands\n");
   printf ("  -S <socket-name>    unix socket to create\n");
   printf ("  -e <commands>       make commands end exit\n");
+  printf ("  -I                  use user and chat IDs in updates instead of names\n");
 
   exit (1);
 }
@@ -567,7 +569,7 @@ char *unix_socket;
 
 void args_parse (int argc, char **argv) {
   int opt = 0;
-  while ((opt = getopt (argc, argv, "u:hk:vNl:fEwWCRdL:DU:G:qP:S:e:"
+  while ((opt = getopt (argc, argv, "u:hk:vNl:fEwWCRdL:DU:G:qP:S:e:I"
 #ifdef HAVE_LIBCONFIG
   "c:p:"
 #else
@@ -658,6 +660,9 @@ void args_parse (int argc, char **argv) {
       break;
     case 'e':
       start_command = optarg;
+      break;
+    case 'I':
+      use_ids ++;
       break;
     case 'h':
     default:


### PR DESCRIPTION
This is useful for bots. If launched with an -I option, all update messages will use IDs for chats and users to make them easier to parse.
