### PR TITLE
Added libevent-devel to Fedora section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ On gentoo:
 
 On Fedora:
 
-     sudo yum install lua-devel openssl-devel libconfig-devel readline-devel
+     sudo yum install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel
 
 On FreeBSD:
 


### PR DESCRIPTION
Dependency libevent-devel was also required to build software on Fedora added it to the Readme
