### PR TITLE
tgl.h: add stdlib.h include

### DIFF
--- a/tgl.h
+++ b/tgl.h
@@ -22,6 +22,7 @@
 
 #include <tgl-layout.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define TGL_MAX_DC_NUM 100
 #define TG_SERVER_1 "173.240.5.1"


### PR DESCRIPTION
This fixes the error

```
gcc -I. -I. -I/usr/local/include -I/opt/local/include -I/opt/local/include/lua-5.1  -I/usr/local/include -I/usr/include -I/usr/include  -I/opt/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -c -MP -MD -MF ./dep/lua-tg.d -MQ ./objs/lua-tg.o -o objs/lua-tg.o lua-tg.c
In file included from lua-tg.c:25:
In file included from ./lua-tg.h:24:
./tgl.h:380:27: error: implicitly declaring library function 'malloc' with type
      'void *(unsigned long)' [-Werror]
  struct tgl_state *TLS = malloc (sizeof (*TLS));
                          ^
./tgl.h:380:27: note: please include the header <stdlib.h> or explicitly provide
      a declaration for 'malloc'
1 error generated.
make: *** [objs/lua-tg.o] Error 1
```
