### PR TITLE
Fix building on FreeBSD and install server.pub file to correct

### DIFF
--- a/main.c
+++ b/main.c
@@ -29,6 +29,10 @@
 #include <termios.h>
 #include <unistd.h>
 #include <assert.h>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
 #if (READLINE == GNU)
 #include <readline/readline.h>
 #else
@@ -844,7 +848,11 @@ int main (int argc, char **argv) {
   running_for_first_time ();
   parse_config ();
 
+  #ifdef __FreeBSD__
+  tgl_set_rsa_key (TLS, "/usr/local/etc/" PROG_NAME "/server.pub");
+  #else
   tgl_set_rsa_key (TLS, "/etc/" PROG_NAME "/server.pub");
+  #endif
   tgl_set_rsa_key (TLS, "tg-server.pub");
 
 


### PR DESCRIPTION
Minor fix to main.c, which corrects building on FreeBSD, and also the location of the server.pub file.

This is what we are doing to the new port I just added for FreeBSD:

http://www.freshports.org/net-im/telegram-cli/
