### PR TITLE
Update config.sample

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -1,7 +1,13 @@
 # This is an empty config file
 # Feel free to put something here
 
-default_profile = "dc1";
+default_profile = "production";
+
+production = {
+  config_directory = ".telegram/production";
+  test = false;
+  msg_num = true;
+};
 
 test_dc1 = {
   config_directory = ".telegram/test_dc1";
@@ -35,12 +41,6 @@ mega = {
 
 new = {
   config_directory = ".telegram/new";
-  test = false;
-  msg_num = true;
-};
-
-production = {
-  config_directory = ".telegram/production";
   test = false;
   msg_num = true;
 };


### PR DESCRIPTION
Setting default profile to one without binlog as activated binlog has different storage and thus confuses people. Default sample config should be working out of the box which is the case now. :-)
