### PR TITLE
resolved: crash after downloading photo/file in deamon/socket mode

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -731,6 +731,7 @@ void do_rename_chat (int arg_num, struct arg args[], struct in_ev *ev) {
 #define DO_LOAD_PHOTO(tp,act,actf) \
 void do_ ## act ## _ ## tp (int arg_num, struct arg args[], struct in_ev *ev) { \
   assert (arg_num == 1);\
+  if (ev) { ev->refcnt ++; vlogprintf (E_WARNING, "refcnt+\n"); }\
   struct tgl_message *M = tgl_message_get (TLS, args[0].num);\
   if (M && !M->service) {\
     if (M->media.type == tgl_message_media_photo) { \
@@ -746,6 +747,7 @@ void do_ ## act ## _ ## tp (int arg_num, struct arg args[], struct in_ev *ev) { 
 #define DO_LOAD_PHOTO_THUMB(tp,act,actf) \
 void do_ ## act ## _ ## tp ## _thumb (int arg_num, struct arg args[], struct in_ev *ev) { \
   assert (arg_num == 1);\
+  if (ev) { ev->refcnt ++; vlogprintf (E_WARNING, "refcnt+\n"); }\
   struct tgl_message *M = tgl_message_get (TLS, args[0].num);\
   if (M && !M->service) {\
     if (M->media.type == tgl_message_media_document) {\


### PR DESCRIPTION
Application used in daemon mode & using socket connection crashed on any input that occurs after downloading or viewing a first photo, video, document or file.

This was caused by missing ev->refcnt increments in do_load_photo and do_load_photo_thumb, causing the callback extradata instance to expire and freed in the print_filename_gw and open_filename_gw callbacks

Eric.