### PR TITLE
Fixes for #516:

### DIFF
--- a/json-tg.c
+++ b/json-tg.c
@@ -3,8 +3,8 @@
 
 #include <jansson.h>
 #include "json-tg.h"
-#include <tgl.h>
-#include <tgl-layout.h>
+#include <tgl/tgl.h>
+#include <tgl/tgl-layout.h>
 #include <assert.h>
 
 #ifndef json_boolean
@@ -331,6 +331,8 @@ json_t *json_pack_service (struct tgl_message *M) {
 
 json_t *json_pack_message (struct tgl_message *M) {  
   json_t *res = json_object ();
+  assert (json_object_set (res, "event", json_string ("message")) >= 0);
+  //will overwriten to service, if service.
 
   assert (json_object_set (res, "id", json_integer (M->id)) >= 0);
   if (!(M->flags & TGLMF_CREATED)) { return res; }
@@ -366,8 +368,17 @@ json_t *json_pack_message (struct tgl_message *M) {
       assert (json_object_set (res, "media", json_pack_media (&M->media)) >= 0);
     }
   } else {
+    assert (json_object_set (res, "event", json_string ("service")) >= 0);
     assert (json_object_set (res, "action", json_pack_service (M)) >= 0);
   }
   return res;
 }
+
+json_t *json_pack_read (struct tgl_message *M) {
+  json_t *res = json_pack_message (M);
+  assert (json_object_set (res, "event", json_string ("read")) >= 0);
+  //this will overwrite "event":"message" to "event":"read".
+  return res;
+}
+
 #endif

--- a/json-tg.h
+++ b/json-tg.h
@@ -8,5 +8,6 @@
 json_t *json_pack_message (struct tgl_message *M);
 json_t *json_pack_updates (unsigned flags);
 json_t *json_pack_peer (tgl_peer_id_t id, tgl_peer_t *P);
+json_t *json_pack_read (struct tgl_message *M);
 #endif
 #endif


### PR DESCRIPTION
Added output when message are marked read (if ```--json```), which fixes Issue [#516] (https://github.com/vysheng/tg/issues/516#issuecomment-101710890)
Also added event field to json which will be send to terminal/main_session:
"event" = "message", "read" (message got read), "service", (events only in secret chats?)  "updates" (peer name change etc), "download" (file downloaded)