### PR TITLE
Fix overflow destination buffer error on yosemite

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,7 @@ CFLAGS=@CFLAGS@
 LDFLAGS=@LDFLAGS@ @OPENSSL_LDFLAGS@
 CPPFLAGS=@CPPFLAGS@ @OPENSSL_INCLUDES@
 DEFS=@DEFS@
-COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC
+COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -Wno-builtin-memcpy-chk-size
 
 EXTRA_LIBS=@LIBS@ @EXTRA_LIBS@ @OPENSSL_LIBS@
 LOCAL_LDFLAGS=-rdynamic -ggdb -levent ${EXTRA_LIBS}
@@ -53,4 +53,3 @@ ${EXE}/telegram-cli: ${TG_OBJECTS} ${LIB}/libtgl.a
 
 clean:
 	rm -rf ${DIR_LIST} config.log config.status > /dev/null || echo "all clean"
-


### PR DESCRIPTION
People trying to install tg in yosemite are having compilation issues. Check https://github.com/vysheng/tg/issues/544 https://github.com/vysheng/tg/issues/487

Adding `-Wno-builtin-memcpy-chk-size` to the Makefile in the `COMPILE_FLAGS` var makes it work.

I tested it with Yosemite 10.10.3 and ubuntu 12.04.3