### PR TITLE
Add required library for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ If using [Homebrew](http://brew.sh/):
      brew install lua
      brew install python
      brew install libevent
+     brew install jansson
      export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.3.8/include"
      export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.3.8/lib"
      ./configure && make


### PR DESCRIPTION
That library was required on `./configure` step for OSX 10.9.4. It mught be same for MacPorts, but I don't using them.