### PR TITLE
New changes to python bindings

### DIFF
--- a/main.c
+++ b/main.c
@@ -127,6 +127,7 @@ int ipv6_enabled;
 char *start_command;
 int disable_link_preview;
 int enable_json;
+int exit_code;
 
 struct tgl_state *TLS;
 
@@ -834,6 +835,7 @@ void sig_term_handler (int signum __attribute__ ((unused))) {
 }
 
 void do_halt (int error) {
+  int retval;
   if (daemonize) {
     return;
   }
@@ -857,8 +859,12 @@ void do_halt (int error) {
   if (sfd > 0) {
     close (sfd);
   }
-  
-  exit (error ? EXIT_FAILURE : EXIT_SUCCESS);
+ 
+  if(exit_code)
+    retval = exit_code;
+  else
+    retval = error ? EXIT_FAILURE : EXIT_SUCCESS;
+  exit (retval);
 }
 
 int main (int argc, char **argv) {

--- a/python-tg.c
+++ b/python-tg.c
@@ -401,7 +401,7 @@ void py_on_loop () {
     return;
   }
 
-  result = PyEval_CallObject(_py_on_loop, Py_None);
+  result = PyEval_CallObject(_py_on_loop, Py_BuildValue("()"));
 
   if(result == NULL)
     PyErr_Print();

--- a/python-tg.c
+++ b/python-tg.c
@@ -1133,6 +1133,21 @@ PyObject* py_status_offline(PyObject *self, PyObject *args) { return push_py_fun
 PyObject* py_send_location(PyObject *self, PyObject *args) { return push_py_func(pq_send_location, args); }
 PyObject* py_extf(PyObject *self, PyObject *args) { return push_py_func(pq_extf, args); }
 
+extern int safe_quit;
+extern int exit_code;
+PyObject* py_safe_quit(PyObject *self, PyObject *args) 
+{
+  int exit_val = 0;
+  if(PyArg_ParseTuple(args, "|i", &exit_val)) {
+    safe_quit = 1;
+    exit_code = exit_val;
+  } else {
+    PyErr_Print();
+  }
+
+  Py_RETURN_NONE;
+}
+
 
 // Store callables for python functions
 TGL_PYTHON_CALLBACK("on_binlog_replay_end", _py_binlog_end);
@@ -1197,6 +1212,8 @@ static PyMethodDef py_tgl_methods[] = {
   {"set_on_user_update", set_py_user_update, METH_VARARGS, ""},
   {"set_on_chat_update", set_py_chat_update, METH_VARARGS, ""},
   {"set_on_loop", set_py_on_loop, METH_VARARGS, ""},
+  {"safe_quit", py_safe_quit, METH_VARARGS, ""},
+  {"safe_exit", py_safe_quit, METH_VARARGS, ""}, // Alias to safe_quit for naming consistancy in python.
   { NULL, NULL, 0, NULL }
 };
 
@@ -1236,14 +1253,6 @@ MOD_INIT(tgl)
   return MOD_SUCCESS_VAL(m);  
 }
 
-/*
-extern int safe_quit;
-static int safe_quit_from_py() {
-  Py_Finalize();
-  safe_quit = 1;
-  return 1;
-}
-*/
 
 void py_init (const char *file) {
   if (!file) { return; }

--- a/python-types.c
+++ b/python-types.c
@@ -999,7 +999,7 @@ tgl_Peer_RichCompare(PyObject *self, PyObject *other, int cmp)
       case Py_GT:
       case Py_LT:
       default:
-        Py_RETURN_NOTIMPLEMENTED;
+        return Py_INCREF(Py_NotImplemented), Py_NotImplemented;
       }
     }
   }

--- a/python-types.c
+++ b/python-types.c
@@ -378,7 +378,7 @@ tgl_Peer_send_msg (tgl_Peer *self, PyObject *args, PyObject *kwargs)
   static char *kwlist[] = {"message", "callback", "preview", "reply", NULL};
 
   char *message;
-  int preview = 1;
+  int preview = -1;
   int reply = 0;
   PyObject *callback = NULL;
 

--- a/python-types.c
+++ b/python-types.c
@@ -969,6 +969,12 @@ tgl_Peer_repr(tgl_Peer *self)
   return ret;
 }
 
+int
+tgl_Peer_hash(PyObject *self)
+{
+  return PyObject_Hash(PyObject_GetAttrString(self, "id"));
+}
+
 PyObject *
 tgl_Peer_RichCompare(PyObject *self, PyObject *other, int cmp)
 {
@@ -1016,7 +1022,7 @@ PyTypeObject tgl_PeerType = {
     0,                            /* tp_as_number */
     0,                            /* tp_as_sequence */
     0,                            /* tp_as_mapping */
-    0,                            /* tp_hash  */
+    (hashfunc)tgl_Peer_hash,      /* tp_hash  */
     0,                            /* tp_call */
     0,                            /* tp_str */
     0,                            /* tp_getattro */

--- a/python-types.c
+++ b/python-types.c
@@ -969,6 +969,38 @@ tgl_Peer_repr(tgl_Peer *self)
   return ret;
 }
 
+PyObject *
+tgl_Peer_RichCompare(PyObject *self, PyObject *other, int cmp)
+{
+  PyObject *result = NULL;
+
+  if(!PyObject_TypeCheck(other, &tgl_PeerType)) {
+    result = Py_False;
+  } else {
+    if(((tgl_Peer*)self)->peer == NULL ||
+       ((tgl_Peer*)other)->peer == NULL) {
+      result = Py_False; // If either object is not properly instantiated, compare is false
+    } else {
+      switch (cmp) {
+      case Py_EQ:
+        result = ((tgl_Peer*)self)->peer->id.id == ((tgl_Peer*)other)->peer->id.id ? Py_True : Py_False;
+        break;
+      case Py_NE:
+        result = ((tgl_Peer*)self)->peer->id.id == ((tgl_Peer*)other)->peer->id.id ? Py_False : Py_True;
+        break;
+      case Py_LE:
+      case Py_GE:
+      case Py_GT:
+      case Py_LT:
+      default:
+        Py_RETURN_NOTIMPLEMENTED;
+      }
+    }
+  }
+  Py_XINCREF(result);
+  return result;
+}
+
 
 PyTypeObject tgl_PeerType = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -994,7 +1026,7 @@ PyTypeObject tgl_PeerType = {
     "tgl Peer",                   /* tp_doc */
     0,                            /* tp_traverse */
     0,                            /* tp_clear */
-    0,                            /* tp_richcompare */
+    (richcmpfunc)tgl_Peer_RichCompare, /* tp_richcompare */
     0,                            /* tp_weaklistoffset */
     0,                            /* tp_iter */
     0,                            /* tp_iternext */


### PR DESCRIPTION
Adding call that can optionally be called on every loop, to enable python based threaded events. Extended tgl.Peer so that it can be compared for equality to other Peer objects. Adding exit function for python and added exit status support to tg. Adding python function to change the global link_preview option.