### PR TITLE
Fix  "bind: Address already in use" error

### DIFF
--- a/main.c
+++ b/main.c
@@ -892,13 +892,17 @@ int main (int argc, char **argv) {
 
   if (port > 0) {
     struct sockaddr_in serv_addr;
-
+    int yes = 1;
     sfd = socket (AF_INET, SOCK_STREAM, 0);
     if (sfd < 0) {
       perror ("socket");
       exit(1);
     }
 
+    if(setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) < 0) {
+      perror("setsockopt");
+      exit(1);
+    }
     memset (&serv_addr, 0, sizeof (serv_addr));
     
     serv_addr.sin_family = AF_INET;


### PR DESCRIPTION
Leading on from https://github.com/vysheng/tg/issues/431

I had the same issue. If telegram was shut down via CTRL-C (or indeed by a crash) whilst using a tcp port as its socket, any attempt to restart was frequently being met by an error `bind: Address already in use`.

After a certain period of time, the error message would go away (for me 60sec) but i wanted to be able to restart the program immediately.

A look at some online information, showed that this is because the port was left in a TIME_WAIT state and telegram could not attach itself to the port until it was released/timed out.

For some systems the time out can be up to 4 minutes. (Look at the value in `/proc/sys/net/ipv4/tcp_fin_timeout`)
- http://unix.stackexchange.com/questions/72089/how-to-connect-to-port-immedeately-avoiding-socket-bind-unable-to-bind-addre
- http://serverfault.com/questions/329845/how-to-forcibly-close-a-socket-in-time-wait

This PR, uses the `SO_REUSEADDR` option for socket connection which allows the reuse of the port immediately.
