### PR TITLE
Add admin field to pack_chat

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -1859,7 +1859,7 @@ void print_user_list_gw (struct tgl_state *TLSR, void *extra, int success, int n
       json_t *res = json_array ();
       int i;
       for (i = num - 1; i >= 0; i--) {
-        json_t *a = json_pack_peer (UL[i]->id, (void *)UL[i]);
+        json_t *a = json_pack_peer (UL[i]->id);
         assert (json_array_append (res, a) >= 0);
       }
       char *s = json_dumps (res, 0);
@@ -1885,7 +1885,7 @@ void print_user_gw (struct tgl_state *TLSR, void *extra, int success, struct tgl
     mprintf (ev, "\n");
   } else {
     #ifdef USE_JSON
-      json_t *res = json_pack_peer (U->id, (void *)U);
+      json_t *res = json_pack_peer (U->id);
       char *s = json_dumps (res, 0);
       mprintf (ev, "%s\n", s);
       json_decref (res);
@@ -1998,7 +1998,7 @@ void print_chat_info_gw (struct tgl_state *TLSR, void *extra, int success, struc
     mpop_color (ev);
   } else {
     #ifdef USE_JSON
-      json_t *res = json_pack_peer (C->id, (void *)C);
+      json_t *res = json_pack_peer (C->id);
       char *s = json_dumps (res, 0);
       mprintf (ev, "%s\n", s);
       json_decref (res);
@@ -2058,7 +2058,7 @@ void print_user_info_gw (struct tgl_state *TLSR, void *extra, int success, struc
     mpop_color (ev);
   } else {
     #ifdef USE_JSON
-      json_t *res = json_pack_peer (U->id, (void *)U);
+      json_t *res = json_pack_peer (U->id);
       char *s = json_dumps (res, 0);
       mprintf (ev, "%s\n", s);
       json_decref (res);
@@ -2085,7 +2085,7 @@ void print_secret_chat_gw (struct tgl_state *TLSR, void *extra, int success, str
     mpop_color (ev);
   } else {
     #ifdef USE_JSON
-      json_t *res = json_pack_peer (E->id, (void *)E);
+      json_t *res = json_pack_peer (E->id);
       char *s = json_dumps (res, 0);
       mprintf (ev, "%s\n", s);
       json_decref (res);
@@ -2130,7 +2130,7 @@ void print_dialog_list_gw (struct tgl_state *TLSR, void *extra, int success, int
       json_t *res = json_array ();
       int i;
       for (i = size - 1; i >= 0; i--) {
-        json_t *a = json_pack_peer (peers[i], tgl_peer_get (TLS, peers[i]));
+        json_t *a = json_pack_peer (peers[i]);
         assert (json_array_append (res, a) >= 0);
       }
       char *s = json_dumps (res, 0);
@@ -2433,7 +2433,7 @@ void json_peer_update (struct in_ev *ev, tgl_peer_t *P, unsigned flags) {
   #ifdef USE_JSON
     json_t *res = json_object ();
     assert (json_object_set (res, "event", json_string ("updates")) >= 0);
-    assert (json_object_set (res, "peer", json_pack_peer (P->id, P)) >= 0);
+    assert (json_object_set (res, "peer", json_pack_peer (P->id)) >= 0);
     assert (json_object_set (res, "updates", json_pack_updates (flags)) >= 0);
     char *s = json_dumps (res, 0);
     mprintf (ev, "%s\n", s);

--- a/interface.c
+++ b/interface.c
@@ -856,6 +856,11 @@ void do_broadcast (struct command *command, int arg_num, struct arg args[], stru
 
 /* {{{ EDITING SELF PROFILE */
 
+void do_get_self(struct command *command, int arg_num, struct arg args[], struct in_ev *ev) {
+  if (ev) { ev->refcnt ++; }
+  tgl_do_get_user_info (TLS, TGL_MK_USER(TLS->our_id), 0, print_user_info_gw, ev);
+}
+
 void do_set_profile_photo (struct command *command, int arg_num, struct arg args[], struct in_ev *ev) {
   assert (arg_num == 1);
   if (ev) { ev->refcnt ++; }
@@ -1344,6 +1349,7 @@ struct command commands[MAX_COMMANDS_SIZE] = {
   {"fwd", {ca_peer, ca_number, ca_period, ca_none}, do_fwd, "fwd <peer> <msg-id>+\tForwards message to peer. Forward to secret chats is forbidden", NULL},
   {"fwd_media", {ca_peer, ca_number, ca_none}, do_fwd_media, "fwd_media <peer> <msg-id>\tForwards message media to peer. Forward to secret chats is forbidden. Result slightly differs from fwd", NULL},
   {"get_message", {ca_number, ca_none}, do_get_message, "get_message <msg-id>\tGet message by id", NULL},
+  {"get_self", {ca_none}, do_get_self, "get_self \tGet our user info", NULL},
   {"help", {ca_none}, do_help, "help\tPrints this help", NULL},
   {"history", {ca_peer, ca_number | ca_optional, ca_number | ca_optional, ca_none}, do_history, "history <peer> [limit] [offset]\tPrints messages with this peer (most recent message lower). Also marks messages as read", NULL},
   {"import_card", {ca_string, ca_none}, do_import_card, "import_card <card>\tGets user by card and prints it name. You can then send messages to him as usual", NULL},

--- a/json-tg.c
+++ b/json-tg.c
@@ -59,6 +59,10 @@ void json_pack_chat (json_t *res, tgl_peer_t *P) {
   assert (json_object_set (res, "title", json_string (P->chat.title)) >= 0);
   assert (json_object_set (res, "members_num", json_integer (P->chat.users_num)) >= 0);
 
+  if (P->chat.admin_id) {
+    assert (json_object_set (res, "admin", json_pack_peer(TGL_MK_USER(P->chat.admin_id))) >= 0);
+  }
+
   if (P->chat.user_list) {
     json_t *m = json_array ();
     assert (m);

--- a/json-tg.c
+++ b/json-tg.c
@@ -66,7 +66,7 @@ void json_pack_chat (json_t *res, tgl_peer_t *P) {
     int i;
     for (i = 0; i < P->chat.users_num; i++) {
       tgl_peer_id_t id = TGL_MK_USER (P->chat.user_list[i].user_id);
-      assert (json_array_append (m, json_pack_peer (id, tgl_peer_get (TLS, id))) >= 0);
+      assert (json_array_append (m, json_pack_peer (id)) >= 0);
     }
 
     assert (json_object_set (res, "members", m) >= 0);
@@ -75,10 +75,12 @@ void json_pack_chat (json_t *res, tgl_peer_t *P) {
 
 
 void json_pack_encr_chat (json_t *res, tgl_peer_t *P) {
-  assert (json_object_set (res, "user", json_pack_peer (TGL_MK_USER (P->encr_chat.user_id), tgl_peer_get (TLS, TGL_MK_USER (P->encr_chat.user_id)))) >= 0);
+  assert (json_object_set (res, "user", json_pack_peer (TGL_MK_USER (P->encr_chat.user_id))) >= 0);
 }
 
-json_t *json_pack_peer (tgl_peer_id_t id, tgl_peer_t *P) {
+json_t *json_pack_peer (tgl_peer_id_t id) {
+  tgl_peer_t *P = tgl_peer_get (TLS, id);
+  assert (P);
   json_t *res = json_object ();
   assert (json_object_set (res, "id", json_integer (tgl_get_peer_id (id))) >= 0);
 
@@ -313,15 +315,15 @@ json_t *json_pack_service (struct tgl_message *M) {
     break;
   case tgl_message_action_chat_add_user:
     assert (json_object_set (res, "type", json_string ("chat_add_user")) >= 0);
-    assert (json_object_set (res, "user", json_pack_peer (tgl_set_peer_id (TGL_PEER_USER, M->action.user), tgl_peer_get (TLS, tgl_set_peer_id (TGL_PEER_USER, M->action.user)))) >= 0);
+    assert (json_object_set (res, "user", json_pack_peer (tgl_set_peer_id (TGL_PEER_USER, M->action.user))) >= 0);
     break;
   case tgl_message_action_chat_add_user_by_link:
     assert (json_object_set (res, "type", json_string ("chat_add_user_link")) >= 0);
-    assert (json_object_set (res, "user", json_pack_peer (tgl_set_peer_id (TGL_PEER_USER, M->action.user), tgl_peer_get (TLS, tgl_set_peer_id (TGL_PEER_USER, M->action.user)))) >= 0);
+    assert (json_object_set (res, "user", json_pack_peer (tgl_set_peer_id (TGL_PEER_USER, M->action.user))) >= 0);
     break;
   case tgl_message_action_chat_delete_user:
     assert (json_object_set (res, "type", json_string ("chat_del_user")) >= 0);
-    assert (json_object_set (res, "user", json_pack_peer (tgl_set_peer_id (TGL_PEER_USER, M->action.user), tgl_peer_get (TLS, tgl_set_peer_id (TGL_PEER_USER, M->action.user)))) >= 0);
+    assert (json_object_set (res, "user", json_pack_peer (tgl_set_peer_id (TGL_PEER_USER, M->action.user))) >= 0);
     break;
   case tgl_message_action_set_message_ttl:
     assert (json_object_set (res, "type", json_string ("set_ttl")) >= 0);
@@ -386,7 +388,7 @@ json_t *json_pack_message (struct tgl_message *M) {
   assert (json_object_set (res, "flags", json_integer (M->flags)) >= 0);
  
   if (tgl_get_peer_type (M->fwd_from_id)) {
-    assert (json_object_set (res, "fwd_from", json_pack_peer (M->fwd_from_id, tgl_peer_get (TLS, M->fwd_from_id))) >= 0);
+    assert (json_object_set (res, "fwd_from", json_pack_peer (M->fwd_from_id)) >= 0);
     assert (json_object_set (res, "fwd_date", json_integer (M->fwd_date)) >= 0);
   }
 
@@ -398,8 +400,8 @@ json_t *json_pack_message (struct tgl_message *M) {
     assert (json_object_set (res, "mention", json_true ()) >= 0);
   }
  
-  assert (json_object_set (res, "from", json_pack_peer (M->from_id, tgl_peer_get (TLS, M->from_id))) >= 0);
-  assert (json_object_set (res, "to", json_pack_peer (M->to_id, tgl_peer_get (TLS, M->to_id))) >= 0);
+  assert (json_object_set (res, "from", json_pack_peer (M->from_id)) >= 0);
+  assert (json_object_set (res, "to", json_pack_peer (M->to_id)) >= 0);
   
   assert (json_object_set (res, "out", json_boolean (M->flags & TGLMF_OUT)) >= 0);
   assert (json_object_set (res, "unread", json_boolean (M->flags & TGLMF_UNREAD)) >= 0);

--- a/json-tg.h
+++ b/json-tg.h
@@ -7,7 +7,7 @@
 #include <tgl/tgl-layout.h>
 json_t *json_pack_message (struct tgl_message *M);
 json_t *json_pack_updates (unsigned flags);
-json_t *json_pack_peer (tgl_peer_id_t id, tgl_peer_t *P);
+json_t *json_pack_peer (tgl_peer_id_t id);
 json_t *json_pack_read (struct tgl_message *M);
 json_t *json_pack_user_status (struct tgl_user *U);
 #endif


### PR DESCRIPTION
Requires the commits from the get_self pr

Also, why is the admin_id not set until chat_info is called?
