### PR TITLE
do fflush instead of readline when readline is disabled.

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -560,7 +560,10 @@ void set_prompt (const char *s) {
 }
 
 void update_prompt (void) {
-  if (readline_disabled) { return; }
+  if (readline_disabled) {
+    fflush (stdout);
+    return;
+  }
   if (read_one_string) { return; }
   print_start ();
   set_prompt (get_default_prompt ());


### PR DESCRIPTION
 - fixes issue when output is getting buffered and is not sent until telegram message is received or program has stopped
 - I used this answer http://stackoverflow.com/a/1716621/74167 for solution