### PR TITLE
Updates Fedora install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On gentoo:
 
 On Fedora:
 
-     sudo yum install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel libjansson-devel python-devel
+     sudo dnf install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel libjansson-devel python-devel
 
 On Archlinux:
 


### PR DESCRIPTION
Replaces `yum` with `dnf`.