### PR TITLE
fix add_contact and rename_contact

### DIFF
--- a/README-LUA
+++ b/README-LUA
@@ -58,8 +58,8 @@ Function_list (arguments are listed aside from cb_function and cb_extra, :
   chat_add_user (chat, user)
   chat_del_user (chat, user)
   
-  add_contactt (phone, first_name, last_name)
-  rename_contactt (phone, first_name, last_name) 
+  add_contact (phone, first_name, last_name)
+  rename_contact (phone, first_name, last_name) 
   
   msg_search (peer, text)
   msg_global_search (text)


### PR DESCRIPTION
The correct function at this moment is working with 1 t. Seems the names changed but readme does not.