### PR TITLE
Fixed random crashes and crash on group link request

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -2135,7 +2135,6 @@ void print_string_gw (struct tgl_state *TLSR, void *extra, int success, const ch
   }
   if (!success) { print_fail (ev); return; }
   mprint_start (ev);
-  mprint_start (ev);
   if (!enable_json) {
     mprintf (ev, "%s\n", name);
   } else {
@@ -3166,7 +3165,7 @@ int readline_active;
 
 int saved_point;
 char *saved_line;
-int prompt_was;
+static int prompt_was;
 
 
 void deactivate_readline (void) {


### PR DESCRIPTION
- (Random crashes) Fixed uninitialized variable prompt_was; please, use static variables to make life easier to everyone.
- Removed duplicate line 2138 that crashed the program on group link request. The print_start/print_end mechanism is weak, there's a lot of redundant code and bugs are hard to catch.