### PR TITLE
Fixes "assertion `TLS->enable_pfs' failed" when usign tg with proxychains

### DIFF
--- a/loop.c
+++ b/loop.c
@@ -856,7 +856,7 @@ int loop (void) {
     }
     bl_do_reset_authorization (TLS);
   }
-
+  tgl_enable_pfs(TLS);
   set_interface_callbacks ();
   tgl_login (TLS);
   net_loop ();


### PR DESCRIPTION

$ proxychains /bin/telegram-cli

will die with the assert error included below when you try to reconnect to Telegram.

telegram-cli: tgl/mtproto-client.c:550: create_temp_auth_key: Assertion `TLS->enable_pfs' failed.
![enable-pfs](https://cloud.githubusercontent.com/assets/13694064/9135802/8ccf8a9a-3ce7-11e5-85b7-07f9834bc7a0.png)
