### PR TITLE
New callback for history messages

### DIFF
--- a/README-LUA
+++ b/README-LUA
@@ -9,6 +9,7 @@ It should have several functions:
   on_our_id(our_id) - Informs about id of currently logged in user.
 
   on_msg_receive(msg) - it is called when we receive new msg (!! may be called before on_binlog_replay_end, than it is old msg).
+  on_msg_history(msg) - it is called when a msg from history is printed.
 
   on_user_update(user,what_changed) - updated info about user. what_changed is array of strings.
   on_chat_update(user,what_changed) - updated info about user. what_changed is array of strings.

--- a/README-PY.md
+++ b/README-PY.md
@@ -20,6 +20,7 @@ Assign python fuctions to the following tgl attributes to set callbacks from TG.
 |`tgl.on_get_difference_end()`| This is called after first get_difference call. So we received all updates after last client execute.|
 |`tgl.on_our_id(our_id)`|Informs about id of currently logged in user.|
 |`tgl.on_msg_receive(msg)`| This is called when we receive new `tgl.Msg` object (*may be called before on_binlog_replay_end, than it is old msg*).|
+|`tgl.on_msg_history(msg)`| This is called when we receive a `tgl.Msg` object from a history printing.|
 |`tgl.on_user_update(peer, what_changed)`|updated info about user. peer is a `tgl.Peer` object representing the user, and what_changed is array of strings.|
 |`tgl.on_chat_update(peer, what_changed)`|updated info about chat. peer is a `tgl.Peer` object representing the chat, and what_changed is array of strings.|
 |`tgl.on_secret_chat_update(peer, what_changed)`|updated info about secret chat. peer is a `tgl.Peer` object representing the secret chat, and  what_changed is array of strings.|

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Telegram messenger CLI [![Build Status](https://travis-ci.org/vysheng/tg.png)](https://travis-ci.org/vysheng/tg)
+## Telegram messenger CLI
 
 Command-line interface for [Telegram](http://telegram.org). Uses readline interface.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Command-line interface for [Telegram](http://telegram.org). Uses readline interface.
 
+**[ This is a fork of [telegram-cli](https://github.com/vysheng/tg) with history callbacks to use in [ibotg](https://github.com/prsai/ibotg) ]**
+
 ### API, Protocol documentation
 
 Documentation for Telegram API is available here: http://core.telegram.org/api
@@ -22,7 +24,7 @@ Fourth, in peer_name '#' are substitued to '@'. (Not applied to appending of '#%
 
 Clone GitHub Repository
 
-     git clone --recursive https://github.com/vysheng/tg.git && cd tg
+     git clone --recursive https://github.com/prsai/tg.git && cd tg
 
 ### Python Support
 

--- a/interface.c
+++ b/interface.c
@@ -3443,7 +3443,8 @@ void print_media (struct in_ev *ev, struct tgl_message_media *M) {
       
     default:
       mprintf (ev, "x = %d\n", M->type);
-      assert (0);
+      M->type = tgl_message_media_unsupported;
+      break;
   }
 }
 

--- a/interface.c
+++ b/interface.c
@@ -2003,6 +2003,9 @@ void print_msg_list_gw (struct tgl_state *TLSR, void *extra, int success, int nu
   if (!enable_json) {
     int i;
     for (i = num - 1; i >= 0; i--) {
+      #ifdef USE_LUA
+        lua_list_msg (ML[i]);
+      #endif
       print_message (ev, ML[i]);
     }
   } else {
@@ -2010,6 +2013,9 @@ void print_msg_list_gw (struct tgl_state *TLSR, void *extra, int success, int nu
       json_t *res = json_array ();
       int i;
       for (i = num - 1; i >= 0; i--) {
+        #ifdef USE_LUA
+          lua_list_msg (ML[i]);
+        #endif
         json_t *a = json_pack_message (ML[i]);
         assert (json_array_append (res, a) >= 0);        
       }

--- a/interface.c
+++ b/interface.c
@@ -2006,6 +2006,9 @@ void print_msg_list_gw (struct tgl_state *TLSR, void *extra, int success, int nu
       #ifdef USE_LUA
         lua_list_msg (ML[i]);
       #endif
+      #ifdef USE_PYTHON
+        py_list_msg (ML[i]);
+      #endif
       print_message (ev, ML[i]);
     }
   } else {
@@ -2015,6 +2018,9 @@ void print_msg_list_gw (struct tgl_state *TLSR, void *extra, int success, int nu
       for (i = num - 1; i >= 0; i--) {
         #ifdef USE_LUA
           lua_list_msg (ML[i]);
+        #endif
+        #ifdef USE_PYTHON
+          py_list_msg (ML[i]);
         #endif
         json_t *a = json_pack_message (ML[i]);
         assert (json_array_append (res, a) >= 0);        

--- a/lua-tg.c
+++ b/lua-tg.c
@@ -550,6 +550,21 @@ void lua_new_msg (struct tgl_message *M) {
   }
 }
 
+void lua_list_msg (struct tgl_message *M) {
+  if (!have_file) { return; }
+  lua_settop (luaState, 0);
+  //lua_checkstack (luaState, 20);
+  my_lua_checkstack (luaState, 20);
+  lua_getglobal (luaState, "on_msg_history");
+  push_message (M);
+  assert (lua_gettop (luaState) == 2);
+
+  int r = ps_lua_pcall (luaState, 1, 0, 0);
+  if (r) {
+    logprintf ("lua: %s\n",  lua_tostring (luaState, -1));
+  }
+}
+
 void lua_secret_chat_update (struct tgl_secret_chat *C, unsigned flags) {
   if (!have_file) { return; }
   lua_settop (luaState, 0);

--- a/lua-tg.h
+++ b/lua-tg.h
@@ -24,6 +24,7 @@
 
 void lua_init (const char *file);
 void lua_new_msg (struct tgl_message *M);
+void lua_list_msg (struct tgl_message *M);
 void lua_our_id (int id);
 void lua_secret_chat_update (struct tgl_secret_chat *U, unsigned flags);
 void lua_user_update (struct tgl_user *U, unsigned flags);

--- a/python-tg.c
+++ b/python-tg.c
@@ -102,6 +102,7 @@ PyObject *_py_binlog_end;
 PyObject *_py_diff_end;
 PyObject *_py_our_id;
 PyObject *_py_new_msg;
+PyObject *_py_list_msg;
 PyObject *_py_secret_chat_update;
 PyObject *_py_user_update;
 PyObject *_py_chat_update;
@@ -304,6 +305,30 @@ void py_new_msg (struct tgl_message *M) {
 
   arglist = Py_BuildValue("(O)", msg);
   result = PyEval_CallObject(_py_new_msg, arglist);
+  Py_DECREF(arglist);
+
+  if(result == NULL)  
+    PyErr_Print();
+  else if(PyUnicode_Check(result))
+    logprintf ("python: %s\n", PyBytes_AsString(PyUnicode_AsASCIIString(result)));
+
+  Py_XDECREF(result);
+}
+
+void py_list_msg (struct tgl_message *M) {
+  if (!python_loaded) { return; }
+  PyObject *msg;
+  PyObject *arglist, *result;
+
+  if(_py_list_msg == NULL) {
+    logprintf("Callback not set for on_msg_history");
+    return;
+  }
+
+  msg = get_message (M);
+
+  arglist = Py_BuildValue("(O)", msg);
+  result = PyEval_CallObject(_py_list_msg, arglist);
   Py_DECREF(arglist);
 
   if(result == NULL)  
@@ -1190,6 +1215,7 @@ TGL_PYTHON_CALLBACK("on_binlog_replay_end", _py_binlog_end);
 TGL_PYTHON_CALLBACK("on_get_difference_end", _py_diff_end);
 TGL_PYTHON_CALLBACK("on_our_id", _py_our_id);
 TGL_PYTHON_CALLBACK("on_msg_receive", _py_new_msg);
+TGL_PYTHON_CALLBACK("on_msg_history", _py_list_msg);
 TGL_PYTHON_CALLBACK("on_secret_chat_update", _py_secret_chat_update);
 TGL_PYTHON_CALLBACK("on_user_update", _py_user_update);
 TGL_PYTHON_CALLBACK("on_chat_update", _py_chat_update);
@@ -1245,6 +1271,7 @@ static PyMethodDef py_tgl_methods[] = {
   {"set_on_get_difference_end", set_py_diff_end, METH_VARARGS, ""},
   {"set_on_our_id", set_py_our_id, METH_VARARGS, ""},
   {"set_on_msg_receive", set_py_new_msg, METH_VARARGS, ""},
+  {"set_on_msg_history", set_py_list_msg, METH_VARARGS, ""},
   {"set_on_secret_chat_update", set_py_secret_chat_update, METH_VARARGS, ""},
   {"set_on_user_update", set_py_user_update, METH_VARARGS, ""},
   {"set_on_chat_update", set_py_chat_update, METH_VARARGS, ""},

--- a/python-tg.c
+++ b/python-tg.c
@@ -296,7 +296,7 @@ void py_new_msg (struct tgl_message *M) {
   PyObject *arglist, *result;
 
   if(_py_new_msg == NULL) {
-    logprintf("Callback not set for on_new_msg");
+    logprintf("Callback not set for on_msg_receive");
     return;
   }
 

--- a/python-tg.h
+++ b/python-tg.h
@@ -27,6 +27,7 @@
 // Python functions
 void py_init (const char *file);
 void py_new_msg (struct tgl_message *M);
+void py_list_msg (struct tgl_message *M);
 void py_our_id (int id);
 void py_secret_chat_update (struct tgl_secret_chat *U, unsigned flags);
 void py_user_update (struct tgl_user *U, unsigned flags);


### PR DESCRIPTION
I have added  a new callback (for lua and python) on_msg_history for messages printed as a result of history command. I need this callback for my project [ibotg](https://github.com/prsai/ibotg).

Also, I have fixed a typo in a log message in the on_msg_receive callback for python.
