### PR TITLE
Fixes Archlinux package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ On Fedora:
 
 On Archlinux:
 
-     yaourt -S telegram-git
+     yaourt -S telegram-cli-git
 
 On FreeBSD:
 
@@ -70,7 +70,7 @@ Then,
 
 On Gentoo: use ebuild provided.
 
-On Arch: https://aur.archlinux.org/packages/telegram-git/ 
+On Arch: https://aur.archlinux.org/packages/telegram-cli-git/ 
 
 #### Mac OS X
 


### PR DESCRIPTION
`telegram-git` doesn't exist anymore in AUR; it's been renamed to `telegram-cli-git`.