### PR TITLE
Automatically mark read conversation when using "msg|reply|fwd|chat_with_peer" 

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -2881,6 +2881,7 @@ void interpreter_chat_mode (char *line) {
   }
   if (strlen (line) > 0) {
     tgl_do_send_message (TLS, chat_mode_id, line, strlen (line), 0, NULL, 0, 0);
+    tgl_do_mark_read (TLS, chat_mode_id, 0, 0);
   }
 }
 

--- a/interface.c
+++ b/interface.c
@@ -123,6 +123,7 @@ int permanent_msg_id_mode;
 int permanent_peer_id_mode;
 int disable_colors;
 extern int alert_sound;
+extern int auto_mark_read;
 extern int binlog_read;
 extern char *home_directory;
 int do_html;
@@ -790,6 +791,8 @@ void do_set (struct command *command, int arg_num, struct arg args[], struct in_
     msg_num_mode = num;
   } else if (!strcmp (args[0].str, "alert")) {
     alert_sound = num;
+  } else if (!strcmp (args[0].str, "auto_mark_read")) {
+    auto_mark_read = num;
   }
 }
 
@@ -846,7 +849,8 @@ void do_msg (struct command *command, int arg_num, struct arg args[], struct in_
   if (ev) { ev->refcnt ++; }
   vlogprintf (E_DEBUG, "reply_id=%d, disable=%d\n", reply_id, disable_msg_preview);
   tgl_do_send_message (TLS, args[0].peer_id, ARG2STR(1), TGL_SEND_MSG_FLAG_REPLY(reply_id) | disable_msg_preview | do_html, NULL, print_msg_success_gw, ev);
-  tgl_do_mark_read (TLS, args[0].peer_id, 0, 0);
+  if (auto_mark_read)
+    tgl_do_mark_read (TLS, args[0].peer_id, 0, 0);
 }
 
 void do_post (struct command *command, int arg_num, struct arg args[], struct in_ev *ev) {
@@ -881,13 +885,15 @@ void do_reply (struct command *command, int arg_num, struct arg args[], struct i
   if (ev) { ev->refcnt ++; }
   tgl_do_reply_message (TLS, &args[0].msg_id, ARG2STR(1), disable_msg_preview | do_html, print_msg_success_gw, ev);
 
-  /* attempt to mark the conversation as read */
-  struct tgl_message *M = tgl_message_get (TLS, &args[0].msg_id);
-  if (M) {
-    /* if it's a chat get its id, else get the user id that is != from our */
-    tgl_peer_id_t id = (M->to_id.peer_type == TGL_PEER_CHAT ||
-                        M->to_id.peer_id != TLS->our_id.peer_id)? M->to_id : M->from_id;
-    tgl_do_mark_read (TLS, id, 0, 0);
+  if (auto_mark_read) {
+    /* attempt to mark the conversation as read */
+    struct tgl_message *M = tgl_message_get (TLS, &args[0].msg_id);
+    if (M) {
+      /* if it's a chat get its id, else get the user id that is != from our */
+      tgl_peer_id_t id = (M->to_id.peer_type == TGL_PEER_CHAT ||
+                          M->to_id.peer_id != TLS->our_id.peer_id)? M->to_id : M->from_id;
+      tgl_do_mark_read (TLS, id, 0, 0);
+    }
   }
 }
 
@@ -987,7 +993,8 @@ void do_fwd (struct command *command, int arg_num, struct arg args[], struct in_
   assert (arg_num <= 1000);
   //if (arg_num == 2) {
   //  tgl_do_forward_message (TLS, args[0].P->id, &args[1].msg_id, 0, print_msg_success_gw, ev);
-  //  tgl_do_mark_read (TLS, args[0].P->id, 0, 0);
+  //  if (auto_mark_read)
+  //    tgl_do_mark_read (TLS, args[0].P->id, 0, 0);
   //} else {
     static tgl_message_id_t *list[1000];
     int i;
@@ -995,7 +1002,8 @@ void do_fwd (struct command *command, int arg_num, struct arg args[], struct in_
       list[i] = &args[i + 1].msg_id;
     }
     tgl_do_forward_messages (TLS, args[0].peer_id, arg_num - 1, (void *)list, 0, print_msg_list_success_gw, ev);
-    tgl_do_mark_read (TLS, args[0].peer_id, 0, 0);
+    if (auto_mark_read)
+      tgl_do_mark_read (TLS, args[0].peer_id, 0, 0);
   //}
 }
 
@@ -1759,7 +1767,7 @@ struct command commands[MAX_COMMANDS_SIZE] = {
   {"send_typing", {ca_peer, ca_number | ca_optional, ca_none}, do_send_typing, "send_typing <peer> [status]\tSends typing notification. You can supply a custom status (range 0-10): none, typing, cancel, record video, upload video, record audio, upload audio, upload photo, upload document, geo, choose contact.", NULL},
   {"send_typing_abort", {ca_peer, ca_none}, do_send_typing_abort, "send_typing_abort <peer>\tSends typing notification abort", NULL},
   {"send_video", {ca_peer, ca_file_name, ca_string_end | ca_optional, ca_none}, do_send_video, "send_video <peer> <file> [caption]\tSends video to peer", NULL},
-  {"set", {ca_string, ca_number, ca_none}, do_set, "set <param> <value>\tSets value of param. Currently available: log_level, debug_verbosity, alarm, msg_num", NULL},
+  {"set", {ca_string, ca_number, ca_none}, do_set, "set <param> <value>\tSets value of param. Currently available: log_level, debug_verbosity, alarm, auto_mark_read, msg_num", NULL},
   {"set_password", {ca_string | ca_optional, ca_none}, do_set_password, "set_password <hint>\tSets password", NULL},
   {"set_profile_name", {ca_string, ca_string, ca_none}, do_set_profile_name, "set_profile_name <first-name> <last-name>\tSets profile name.", NULL},
   {"set_profile_photo", {ca_file_name_end, ca_none}, do_set_profile_photo, "set_profile_photo <filename>\tSets profile photo. Photo will be cropped to square", NULL},
@@ -2881,7 +2889,8 @@ void interpreter_chat_mode (char *line) {
   }
   if (strlen (line) > 0) {
     tgl_do_send_message (TLS, chat_mode_id, line, strlen (line), 0, NULL, 0, 0);
-    tgl_do_mark_read (TLS, chat_mode_id, 0, 0);
+    if (auto_mark_read)
+      tgl_do_mark_read (TLS, chat_mode_id, 0, 0);
   }
 }
 

--- a/main.c
+++ b/main.c
@@ -118,6 +118,7 @@ char *start_command;
 int disable_link_preview;
 int enable_json;
 int alert_sound;
+int auto_mark_read;
 int exit_code;
 int permanent_msg_id_mode;
 int permanent_peer_id_mode;
@@ -470,6 +471,7 @@ void usage (void) {
   printf ("  --disable-colors/-C                  disable color output\n");
   printf ("  --disable-readline/-R                disable readline\n");
   printf ("  --alert/-A                           enable bell notifications\n");
+  printf ("  --auto-mark-read/-M                  mark read conversation after sending a message\n");
   printf ("  --daemonize/-d                       daemon mode\n");
   printf ("  --logname/-L <log-name>              log file name\n");
   printf ("  --username/-U <user-name>            change uid after start\n");
@@ -627,6 +629,7 @@ void args_parse (int argc, char **argv) {
     {"disable-colors", no_argument, 0, 'C'},
     {"disable-readline", no_argument, 0, 'R'},
     {"alert", no_argument, 0, 'A'},
+    {"auto-mark-read", no_argument, 0, 'M'},
     {"daemonize", no_argument, 0, 'd'},
     {"logname", required_argument, 0, 'L'},
     {"username", required_argument, 0, 'U'},
@@ -652,7 +655,7 @@ void args_parse (int argc, char **argv) {
 
 
   int opt = 0;
-  while ((opt = getopt_long (argc, argv, "u:hk:vNl:fEwWCRAdL:DU:G:qP:S:e:I6b"
+  while ((opt = getopt_long (argc, argv, "u:hk:vNl:fEwWCRAMdL:DU:G:qP:S:e:I6b"
 #ifdef HAVE_LIBCONFIG
   "c:p:"
 #else
@@ -744,6 +747,9 @@ void args_parse (int argc, char **argv) {
       break;
     case 'A':
       alert_sound = 1;
+      break;
+    case 'M':
+      auto_mark_read = 1;
       break;
     case 'd':
       daemonize ++;


### PR DESCRIPTION
Assuming that when you send a message in a conversation you read also the previous messages, I appended the call to `tgl_do_mark_read` in `do_msg`, `do_reply`, `do_fwd`, and `chat_with_peer`.

This mainly because i found annoying marking read all the conversation all the times.
