### PR TITLE
fix: null error string breaks json mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tgl"]
 	path = tgl
-	url = https://github.com/vysheng/tgl.git
+	url = git@github.com:ant9000/tgl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tgl"]
 	path = tgl
-	url = git@github.com:ant9000/tgl.git
+	url = https://github.com/ant9000/tgl.git

--- a/interface.c
+++ b/interface.c
@@ -1907,7 +1907,7 @@ void print_fail (struct in_ev *ev) {
     json_t *res = json_object ();
     assert (json_object_set (res, "result", json_string ("FAIL")) >= 0);
     assert (json_object_set (res, "error_code", json_integer (TLS->error_code)) >= 0);
-    assert (json_object_set (res, "error", json_string (TLS->error)) >= 0);
+    assert (json_object_set (res, "error", json_string (TLS->error ? TLS->error : "")) >= 0);
     char *s = json_dumps (res, 0);
     mprintf (ev, "%s\n", s);
     json_decref (res);

--- a/interface.c
+++ b/interface.c
@@ -1335,6 +1335,12 @@ void do_delete_msg (struct command *command, int arg_num, struct arg args[], str
   tgl_do_delete_msg (TLS, args[0].num, print_success_gw, ev);
 }
 
+void do_delete_history (struct command *command, int arg_num, struct arg args[], struct in_ev *ev) {
+  assert (arg_num == 2);
+  if (ev) { ev->refcnt ++; }
+  tgl_do_delete_history (TLS, args[0].P->id, args[1].num != NOT_FOUND ? args[1].num : 0, print_success_gw, ev);
+}
+
 void do_get_message (struct command *command, int arg_num, struct arg args[], struct in_ev *ev) {
   assert (arg_num == 1);
   if (ev) { ev->refcnt ++; }
@@ -1405,6 +1411,7 @@ struct command commands[MAX_COMMANDS_SIZE] = {
   {"create_secret_chat", {ca_user, ca_none}, do_create_secret_chat, "create_secret_chat <user>\tStarts creation of secret chat", NULL},
   {"del_contact", {ca_user, ca_none}, do_del_contact, "del_contact <user>\tDeletes contact from contact list", NULL},
   {"delete_msg", {ca_number, ca_none}, do_delete_msg, "delete_msg <msg-id>\tDeletes message", NULL},
+  {"delete_history", {ca_peer, ca_number | ca_optional, ca_none}, do_delete_history, "delete_history <peer> [offset=0]\tDeletes all history with peer", NULL},
   {"dialog_list", {ca_number | ca_optional, ca_number | ca_optional, ca_none}, do_dialog_list, "dialog_list [limit=100] [offset=0]\tList of last conversations", NULL},
   {"export_card", {ca_none}, do_export_card, "export_card\tPrints card that can be imported by another user with import_card method", NULL},
   {"export_chat_link", {ca_chat, ca_none}, do_export_chat_link, "export_chat_link\tPrints chat link that can be used to join to chat", NULL},


### PR DESCRIPTION
A few methods from `tgl/queries.c` use the following code for returning a failure:

``` C
callback (TLS, callback_extra, 0, 0);
```

that breaks the assertion test in `print_fail` when the requested output is JSON. My fix simply uses an empty error string for that case.
