### PR TITLE
update dpkg build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,10 +8,12 @@ Build-Depends: 	debhelper (>= 8.0.0),
 		libreadline-dev,
 		libconfig-dev,
 		libssl-dev,
-		lua5.1,
-		liblua5.1-dev,
+		lua5.2,
+		liblua5.2-dev,
 		lua-lgi,
-		libevent-dev
+		libevent-dev,
+		libjansson-dev,
+		libpython-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/vysheng/tg
 Vcs-Git: git://github.com/vysheng/tg.git


### PR DESCRIPTION
The patch update in `debian/control` the dpkg build dependencies. A Debian `*.deb` package can be build as user with the command `dpkg-buildpackage -b`.