### PR TITLE
Error message for on_loop in python script missing is wrong

### DIFF
--- a/README-PY.md
+++ b/README-PY.md
@@ -23,6 +23,7 @@ Assign python fuctions to the following tgl attributes to set callbacks from TG.
 |`tgl.on_user_update(peer, what_changed)`|updated info about user. peer is a `tgl.Peer` object representing the user, and what_changed is array of strings.|
 |`tgl.on_chat_update(peer, what_changed)`|updated info about chat. peer is a `tgl.Peer` object representing the chat, and what_changed is array of strings.|
 |`tgl.on_secret_chat_update(peer, what_changed)`|updated info about secret chat. peer is a `tgl.Peer` object representing the secret chat, and  what_changed is array of strings.|
+|`tgl.on_loop()` | This is called every now and then.|
 
 Python Callback Signatures
 =========================

--- a/python-tg.c
+++ b/python-tg.c
@@ -397,7 +397,7 @@ void py_on_loop () {
   PyObject *result;
 
   if(_py_on_loop == NULL) {
-    logprintf("Callback not set for on_chat_update");
+    logprintf("Callback not set for on_loop");
     return;
   }
 


### PR DESCRIPTION
Having on_loop not defined in a python scripts leads to an error message saying on_chat_update is not set. This one took me a looooooooong time to find.