### PR TITLE
Correctly set online flag in Peer class (Python)

### DIFF
--- a/python-types.c
+++ b/python-types.c
@@ -161,7 +161,7 @@ tgl_Peer_getuser_status(tgl_Peer *self, void *closure)
   switch(self->peer->id.type) {
     case TGL_PEER_USER:
       ret = PyDict_New();
-      PyDict_SetItemString(ret, "online", self->peer->user.status.online? Py_True : Py_False);
+      PyDict_SetItemString(ret, "online", self->peer->user.status.online > 0 ? Py_True : Py_False);
       PyDict_SetItemString(ret, "when", get_datetime(self->peer->user.status.when));
 
       break;


### PR DESCRIPTION
The `online` flag in `struct tgl_user_status` is not a boolean.  Rather, positive values indicate "online" while negative values indicate "offline".
