### PR TITLE
Line up command descriptions in 'help'

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -722,7 +722,8 @@ void do_help (struct command *command, int arg_num, struct arg args[], struct in
   struct command *cmd = commands;
   while (cmd->name) {
     if (!args[0].str || !strcmp (args[0].str, cmd->name)) {
-      mprintf (ev, "%s\n", cmd->desc);
+      int tab_index = strchr (cmd->desc, '\t') - cmd->desc;
+      mprintf (ev, "%-55.*s %s\n", tab_index, cmd->desc, cmd->desc + tab_index + 1);
       total ++;
     }
     cmd ++;


### PR DESCRIPTION
Before:
<img width="1440" alt="before" src="https://cloud.githubusercontent.com/assets/7543552/14212417/68b6a37c-f83b-11e5-96fd-7b662f429498.png">

After:
<img width="1440" alt="after" src="https://cloud.githubusercontent.com/assets/7543552/14212418/68b72d24-f83b-11e5-9c81-b75461a6cacd.png">

Alternative (just remove the `-` in the `mprintf` format specifier):
<img width="1440" alt="alternative" src="https://cloud.githubusercontent.com/assets/7543552/14212545/1f032b1e-f83c-11e5-8b1b-b8ce3ac816d4.png">
