### PR TITLE
adds homebrew tap to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Python support is currently limited to Python 2.7 or Python 3.1+. Other versions
 Install libs: readline, openssl and (if you want to use config) libconfig, liblua, python and libjansson.
 If you do not want to use them pass options --disable-libconfig, --disable-liblua, --disable-python and --disable-json respectively.
 
-On Ubuntu/Debian use: 
+On Ubuntu/Debian use:
 
-     sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev libjansson-dev libpython-dev make 
+     sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev libjansson-dev libpython-dev make
 
 On gentoo:
 
@@ -78,6 +78,11 @@ The client depends on [readline library](http://cnswww.cns.cwru.edu/php/chet/rea
 
 If using [Homebrew](http://brew.sh/):
 
+     brew tap ivoputzer/tg
+     brew install tg
+
+or manually:
+
      brew install libconfig readline lua python libevent jansson
      export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.3.8/include"
      export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.3.8/lib"
@@ -86,7 +91,7 @@ If using [Homebrew](http://brew.sh/):
 Thanks to [@jfontan](https://github.com/vysheng/tg/issues/3#issuecomment-28293731) for this solution.
 
 If using [MacPorts](https://www.macports.org):
-     
+
      sudo port install libconfig-hr
      sudo port install readline
      sudo port install lua51
@@ -111,14 +116,14 @@ Then build:
 
 If you manage to launch it on other UNIX, please let me know.
 
-### Contacts 
+### Contacts
 If you would like to ask a question, you can write to my telegram or to the github (or both). To contact me via telegram, you should use import_card method with argument 000653bf:0738ca5d:5521fbac:29246815:a27d0cda
 
 
 ### Usage
 
     bin/telegram-cli -k <public-server-key>
-    
+
 By default, the public key is stored in tg-server.pub in the same folder or in /etc/telegram-cli/server.pub. If not, specify where to find it:
 
     bin/telegram-cli -k tg-server.pub
@@ -128,10 +133,10 @@ Client support TAB completion and command history.
 Peer refers to the name of the contact or dialog and can be accessed by TAB completion.
 For user contacts peer name is Name <underscore> Lastname with all spaces changed to underscores.
 For chats it is it's title with all spaces changed to underscores
-For encrypted chats it is <Exсlamation mark> <underscore> Name <underscore> Lastname with all spaces changed to underscores. 
+For encrypted chats it is <Exсlamation mark> <underscore> Name <underscore> Lastname with all spaces changed to underscores.
 
 If two or more peers have same name, <sharp>number is appended to the name. (for example A_B, A_B#1, A_B#2 and so on)
-  
+
 ### Supported commands
 
 #### Messaging


### PR DESCRIPTION
i wrote a homebrew formula for easier osx installation, would you consider to add the the installation snippet to your readme?

```
 brew tap ivoputzer/tg
 brew install tg
```
