### PR TITLE
update gentoo ebuild

### DIFF
--- a/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
+++ b/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
@@ -13,7 +13,7 @@ else
 fi
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="lua json +python"
+IUSE="lua json python"
 REQUIRED_USE="python? (lua json)"
 
 DEPEND="

--- a/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
+++ b/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
@@ -14,6 +14,7 @@ fi
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="lua json +python"
+REQUIRED_USE="python? (lua json)"
 
 DEPEND="
 	sys-libs/zlib

--- a/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
+++ b/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
@@ -1,43 +1,40 @@
-# Copyright 1999-2013 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
-# $Header: $
+EAPI=6
 
-EAPI=5
+inherit git-r3
 
-EGIT_REPO_URI="https://github.com/vysheng/tg.git"
-EGIT_BRANCH="master"
-EGIT_HAS_SUBMODULES=1
-inherit git-2
-IUSE="+lua +json +python"
-DESCRIPTION="Command line interface client for Telegram"
 HOMEPAGE="https://github.com/vysheng/tg"
+DESCRIPTION="Command line interface client for Telegram"
+EGIT_REPO_URI="https://github.com/vysheng/tg.git"
+if [[ "${PV}" -ne "9999" ]]; then
+	EGIT_COMMIT="refs/tags/${PV}"
+	KEYWORDS="~amd64 ~x86"
+else
+	KEYWORDS=""
+fi
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+IUSE="lua json +python"
 
-DEPEND="sys-libs/zlib
+DEPEND="
+	sys-libs/zlib
 	sys-libs/readline
 	dev-libs/libconfig
 	dev-libs/openssl
 	dev-libs/libevent
 	lua? ( dev-lang/lua )
 	json? ( dev-libs/jansson )
-	python? ( dev-lang/python )"
-
-src_unpack() {
-	git-2_src_unpack
-	cd $EGIT_SOURCEDIR
-	git submodule update --init --recursive
-}
+	python? ( dev-lang/python )
+	"
+RDEPEND="${DEPEND}"
 
 src_configure() {
-	econf $(use_enable lua liblua )
-	econf $(use_enable python python )
-	econf $(use_enable json json )
+	econf $(use_enable lua liblua) \
+	      $(use_enable python) \
+	      $(use_enable json)
 }
 
 src_install() {
-	newbin bin/telegram-cli telegram-cli
+	dobin bin/telegram-cli
 
 	insinto /etc/telegram-cli/
 	newins tg-server.pub server.pub

--- a/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
+++ b/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
@@ -14,7 +14,7 @@ fi
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="lua json python"
-REQUIRED_USE="python? (lua json)"
+REQUIRED_USE="python? ( lua json )"
 
 DEPEND="
 	sys-libs/zlib

--- a/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
+++ b/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
@@ -14,7 +14,6 @@ fi
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="lua json python"
-REQUIRED_USE="python? ( lua json )"
 
 DEPEND="
 	sys-libs/zlib

--- a/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
+++ b/gentoo/net-im/telegram-cli/telegram-cli-9999.ebuild
@@ -13,7 +13,7 @@ else
 fi
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="lua json python"
+IUSE="lua json"
 
 DEPEND="
 	sys-libs/zlib
@@ -23,13 +23,11 @@ DEPEND="
 	dev-libs/libevent
 	lua? ( dev-lang/lua )
 	json? ( dev-libs/jansson )
-	python? ( dev-lang/python )
 	"
 RDEPEND="${DEPEND}"
 
 src_configure() {
 	econf $(use_enable lua liblua) \
-	      $(use_enable python) \
 	      $(use_enable json)
 }
 


### PR DESCRIPTION
summary of changes:
- use EAPI 6 instead of 5
- use git-r3 instead of git-2
- allow file to be copied as telegram-cli-<version>.ebuild to get a previous version
- disable lua and json by default to follow the usual Gentoo standard of minimalism; leave python enabled since it is installed on effectively every Gentoo system because of Portage
