### PR TITLE
Update README.md with openssl C & LD FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ The client depends on [readline library](http://cnswww.cns.cwru.edu/php/chet/rea
 If using [Homebrew](http://brew.sh/):
 
      brew install libconfig readline lua python libevent jansson
-     export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.3.8/include"
-     export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.3.8/lib"
+     export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.3.8/include -I/usr/local/opt/openssl/include"
+     export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.3.8/lib -L/usr/local/opt/openssl/lib"
      ./configure && make
 
 Thanks to [@jfontan](https://github.com/vysheng/tg/issues/3#issuecomment-28293731) for this solution.


### PR DESCRIPTION
Using openssl from Homebrew seems to require this flags.

Also, current readline version there is 7.0.