### PR TITLE
Include "username" (if present) to "json_pack_channel()"

### DIFF
--- a/json-tg.c
+++ b/json-tg.c
@@ -99,6 +99,9 @@ void json_pack_channel (json_t *res, tgl_peer_t *P) {
   assert (json_object_set (res, "participants_count", json_integer (P->channel.participants_count)) >= 0);
   assert (json_object_set (res, "admins_count", json_integer (P->channel.admins_count)) >= 0);
   assert (json_object_set (res, "kicked_count", json_integer (P->channel.kicked_count)) >= 0);
+  if(P->channel.username) {
+    assert (json_object_set (res, "username", json_string (P->channel.username)) >= 0);
+  }
 }
 
 


### PR DESCRIPTION
When using `--json` mode, channels public links (@usernames) are not included, while in text mode links are displayed. Fixes #1034 