### PR TITLE
Updated README.md instructions to install Fedora build prerequisite package jansson-devel (libjansson)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tgl"]
 	path = tgl
-	url = https://github.com/vysheng/tgl.git
+	url = https://github.com/alexkoster/tgl.git

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On gentoo:
 
 On Fedora:
 
-     sudo dnf install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel libjansson-devel python-devel
+     sudo dnf install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel jansson-devel python-devel
 
 On Archlinux:
 


### PR DESCRIPTION
Just a minor update to the Fedora prerequisite install instructions. Package libjansson-devel does not exist in the Fedora repositories and a package named jansson-devel I believe is a drop-in replacement for its functionality.