### PR TITLE
Update MacOS compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ The client depends on [readline library](http://cnswww.cns.cwru.edu/php/chet/rea
 If using [Homebrew](http://brew.sh/):
 
      brew install libconfig readline lua python libevent jansson
-     export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.3.8/include"
-     export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.3.8/lib"
-     ./configure && make
+     export READLINEPATH=$(brew --prefix readline)
+     export OPENSSLPATH=$(brew --prefix openssl)
+     export CFLAGS="-I/usr/local/include -I$READLINEPATH/include -I$OPENSSLPATH/include"
+     export LDFLAGS="-L/usr/local/lib -L$READLINEPATH/lib -L$OPENSSLPATH/lib"
+     export CPPFLAGS="-I/usr/local/opt/openssl/include -W"
+     ./configure --with-openssl=/usr/local/opt/openssl && make CFSUFFIX='-Wno-error=unused'
 
 Thanks to [@jfontan](https://github.com/vysheng/tg/issues/3#issuecomment-28293731) for this solution.
 


### PR DESCRIPTION
Distilled ideas from https://github.com/vysheng/tg/issues/811 and https://github.com/vysheng/tg/issues/1132 and a trick to avoid failing the compile on any warning - otherwise make compile fails on an ununsed function