### PR TITLE
wrong package name for jansson on fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On gentoo:
 
 On Fedora:
 
-     sudo dnf install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel libjansson-devel python-devel
+     sudo dnf install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel jansson-devel python-devel
 
 On Archlinux:
 


### PR DESCRIPTION
changed from "libjansson-devel" to "jansson-devel"