### PR TITLE
Readme libreadline newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ The client depends on [readline library](http://cnswww.cns.cwru.edu/php/chet/rea
 If using [Homebrew](http://brew.sh/):
 
      brew install libconfig readline lua python libevent jansson
-     export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/6.3.8/include"
-     export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/6.3.8/lib"
+     export CFLAGS="-I/usr/local/include -I/usr/local/Cellar/readline/7.0.3_1/include"
+     export LDFLAGS="-L/usr/local/lib -L/usr/local/Cellar/readline/7.0.3_1/lib"
      ./configure && make
 
 Thanks to [@jfontan](https://github.com/vysheng/tg/issues/3#issuecomment-28293731) for this solution.


### PR DESCRIPTION
Libreadline has a newer version (OSX Version 10.13.4)