### PR TITLE
Correct the description of --exec

### DIFF
--- a/main.c
+++ b/main.c
@@ -477,7 +477,7 @@ void usage (void) {
   printf ("  --disable-output/-D                  disable output\n");
   printf ("  --tcp-port/-P <port>                 port to listen for input commands\n");
   printf ("  --udp-socket/-S <socket-name>        unix socket to create\n");
-  printf ("  --exec/-e <commands>                 make commands end exit\n");
+  printf ("  --exec/-e <command>                  make a single command end then exit safely\n");
   printf ("  --disable-names/-I                   use user and chat IDs in updates instead of names\n");
   printf ("  --enable-ipv6/-6                     use ipv6 (may be unstable)\n");
   printf ("  --help/-h                            prints this help\n");


### PR DESCRIPTION
The description now does not speak of multiple commands but of a single command and specifies that the output is safe (and therefore awaits the end of operations in progress). The --exec command executes a single command and then exits safely.