### PR TITLE
zlib1g-dev dependency needed on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you do not want to use them pass options --disable-libconfig, --disable-liblu
 
 On Ubuntu/Debian use: 
 
-     sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev libjansson-dev libpython-dev make 
+     sudo apt-get install libreadline-dev libconfig-dev zlib1g-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev libjansson-dev libpython-dev make 
 
 On gentoo:
 


### PR DESCRIPTION
The package zlib1g-dev needed to be added to the package install line for Debian/Ubuntu. I tried building the project and installed the required packages above; however, when I did so the ./configure failed to run due to a missing zlib requirement. Adding the above package resolved the issue.