### PR TITLE
Update Ubuntu requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you do not want to use them pass options --disable-libconfig, --disable-liblu
 On Ubuntu/Debian use: 
 
      sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev libjansson-dev libpython-dev make 
+     lsb_release -cs | grep bionic > /dev/null && sudo apt install libssl1.0-dev
 
 On gentoo:
 


### PR DESCRIPTION
Ubuntu bionic won't build w/o libssl1.0-dev, so include. This should reduce the number of open issues 
in the future.

This is the error
```
tgl/crypto/rsa_pem_openssl.c: In function ‘TGLC_rsa_new’:
tgl/crypto/rsa_pem_openssl.c:41:6: error: dereferencing pointer to incomplete type ‘RSA {aka struct rsa_st}’
   ret->e = unwrap_bn (TGLC_bn_new ());
      ^~
tgl/crypto/rsa_pem_openssl.c: In function ‘TGLC_rsa_n’:
tgl/crypto/rsa_pem_openssl.c:52:1: error: control reaches end of non-void function [-Werror=return-type]
 RSA_GETTER(n);
 ^~~~~~~~~~
tgl/crypto/rsa_pem_openssl.c: In function ‘TGLC_rsa_e’:
tgl/crypto/rsa_pem_openssl.c:53:1: error: control reaches end of non-void function [-Werror=return-type]
 RSA_GETTER(e);
 ^~~~~~~~~~
```