### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: c
+arch: 
+  - amd64
+  - ppc64le
 
 compiler:
   - gcc


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

PS: Observed compilation issue with clang (on get_peer function. It is same as https://github.com/vysheng/tg/issues/1683. Commenting the inline function defn should fix it.