### PR TITLE
This patch allows telegram-cli to build on Apple Silicon

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,7 +2,7 @@ srcdir=@srcdir@
 
 CFLAGS=@CFLAGS@
 LDFLAGS=@LDFLAGS@ @OPENSSL_LDFLAGS@
-CPPFLAGS=@CPPFLAGS@ @OPENSSL_INCLUDES@
+CPPFLAGS=@CPPFLAGS@ @OPENSSL_INCLUDES@  -DSYSCONFDIR='"@sysconfdir@"'
 DEFS=@DEFS@
 COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Werror -Wextra -Wno-missing-field-initializers -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC
 EXTRA_LIBS=@LIBS@ @EXTRA_LIBS@ @OPENSSL_LIBS@

--- a/main.c
+++ b/main.c
@@ -990,8 +990,10 @@ int main (int argc, char **argv) {
   running_for_first_time ();
   parse_config ();
 
-  #ifdef __FreeBSD__
-  tgl_set_rsa_key (TLS, "/usr/local/etc/" PROG_NAME "/server.pub");
+  #if defined(SYSCONFDIR)
+  /* if --sysconfdir was provided to configure use it, not touching FreeBSD as I'm not sure if
+     the default is correct there */
+  tgl_set_rsa_key (TLS, SYSCONFDIR PROG_NAME "/server.pub");
   #else
   tgl_set_rsa_key (TLS, "/etc/" PROG_NAME "/server.pub");
   #endif


### PR DESCRIPTION
by leveraging the sysconfdir macro from autoconf

1. Add SYSCONFDIR define which is set to the autoconf provided @sysconfdir@
2. Remove the FreeBSD #ifdef around tgl_set_rsa_key, and replace
   with #ifdef SYSCONFDIR around tgl_set_rsa_key, to use SYSCONFDIR for location of server.pub