### PR TITLE
fix libpython library for ubuntu/devian installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you do not want to use them pass options --disable-libconfig, --disable-liblu
 
 On Ubuntu/Debian use: 
 
-     sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev libjansson-dev libpython-dev make 
+     sudo apt-get install libreadline-dev libconfig-dev libssl-dev lua5.2 liblua5.2-dev libevent-dev libjansson-dev libpython3-dev make 
 
 On gentoo:
 


### PR DESCRIPTION
Following the installation for ubuntu/Debian as suggested by the readme bring me to this notice:

![image](https://user-images.githubusercontent.com/25538711/132354471-36777ac7-8cfc-4615-a7fe-650f7f49e9e1.png)

Changing the last lbrary _libpython-dev_ to _libpython2-dev_ fixed the issue.