### PR TITLE
Fix write length

### DIFF
--- a/main.c
+++ b/main.c
@@ -821,7 +821,7 @@ void termination_signal_handler (int signum) {
     rl_cleanup_after_signal ();
   }
   
-  if (write (1, "SIGNAL received\n", 18) < 0) { 
+  if (write (1, "SIGNAL received\n", 17) < 0) {
     // Sad thing
   }
  


### PR DESCRIPTION
Fixing warning:
```
main.c: In function ‘termination_signal_handler’:
main.c:824:7: error: ‘write’ reading 18 bytes from a region of size 17 [-Werror=stringop-overread]
  824 |   if (write (1, "SIGNAL received\n", 18) < 0) {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from main.c:29:
/usr/include/unistd.h:378:16: note: in a call to function ‘write’ declared with attribute ‘access (read_only, 2, 3)’
  378 | extern ssize_t write (int __fd, const void *__buf, size_t __n) __wur
      |                ^~~~~
main.c:824:7: error: ‘write’ reading 18 bytes from a region of size 17 [-Werror=stringop-overread]
  824 |   if (write (1, "SIGNAL received\n", 18) < 0) {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unistd.h:378:16: note: in a call to function ‘write’ declared with attribute ‘access (read_only, 2, 3)’
  378 | extern ssize_t write (int __fd, const void *__buf, size_t __n) __wur
      |                ^~~~~
main.c:824:7: error: ‘write’ reading 18 bytes from a region of size 17 [-Werror=stringop-overread]
  824 |   if (write (1, "SIGNAL received\n", 18) < 0) {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unistd.h:378:16: note: in a call to function ‘write’ declared with attribute ‘access (read_only, 2, 3)’
  378 | extern ssize_t write (int __fd, const void *__buf, size_t __n) __wur
      |                ^~~~~
```