### PR TITLE
Changed libjansson-devel to jansson-devel for Fedora.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On gentoo:
 
 On Fedora:
 
-     sudo dnf install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel libjansson-devel python-devel
+     sudo dnf install lua-devel openssl-devel libconfig-devel readline-devel libevent-devel jansson-devel python-devel
 
 On Archlinux:
 

--- a/main.c
+++ b/main.c
@@ -820,9 +820,10 @@ void termination_signal_handler (int signum) {
     rl_free_line_state ();
     rl_cleanup_after_signal ();
   }
-  
-  if (write (1, "SIGNAL received\n", 18) < 0) { 
-    // Sad thing
+
+  if (write (1, "SIGNAL received\n", 17) < 0) {
+
+        // Sad thing
   }
  
   if (unix_socket) {


### PR DESCRIPTION
Fedora has changed the name of libjansson-devel package to jansson-devel, I changed the installation requirements in README.md to correctly reflect this. 